### PR TITLE
Make private methods of Knock::AuthTokenController protected

### DIFF
--- a/app/controllers/knock/auth_token_controller.rb
+++ b/app/controllers/knock/auth_token_controller.rb
@@ -8,7 +8,7 @@ module Knock
       render json: { jwt: auth_token.token }, status: :created
     end
 
-  private
+  protected
     def authenticate!
       raise ActiveRecord::RecordNotFound unless user.authenticate(auth_params[:password])
     end


### PR DESCRIPTION
This change will make possible writing own controller, which extends `Knock::AuthTokenController` and reuse methods.